### PR TITLE
Update jazzy dependencies & small change in his execution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 gem "fastlane"
 gem "xcpretty"
+
+group :development do
+    gem 'jazzy'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,14 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    jazzy (0.0.20)
+      activesupport (~> 4.1)
+      mustache (~> 0.99)
+      nokogiri (~> 1.6)
+      redcarpet (~> 3.2)
+      rouge (~> 1.5)
+      sass (~> 3.4)
+      sqlite3 (~> 1.3)
     json (1.8.3)
     krausefx-shenzhen (0.14.5)
       aws-sdk (~> 1.0)
@@ -126,6 +134,7 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    mustache (0.99.8)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (3.0.1)
@@ -158,11 +167,14 @@ GEM
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
+    redcarpet (3.3.3)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rouge (1.10.1)
     rubyzip (1.1.7)
+    sass (3.4.19)
     security (0.1.3)
     sigh (0.10.9)
       fastlane_core (>= 0.19.0, < 1.0.0)
@@ -182,6 +194,7 @@ GEM
       multi_xml (~> 0.5)
       plist (~> 3.1)
       pry
+    sqlite3 (1.3.11)
     terminal-notifier (1.6.3)
     terminal-table (1.4.5)
     thread_safe (0.3.5)
@@ -206,6 +219,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
+  jazzy
   xcpretty
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ And execute `pod install`. Remember to open the project using the file `.xcworks
 Before proposing a new PR, it must include update documentation. It's generated using [Jazzy](https://github.com/Realm/jazzy) and the following command:
 
 ```bash
-jazzy -o Documentation -a GitDo -g https://github.com/gitdoapp --readme README.md
+jazzy -o Documentation -a GitDo -g https://github.com/gitdoapp --readme README.md --swift-version 2.1
 ```
 
 ## Documentation


### PR DESCRIPTION
`jazzy` needs a param to be used with XCode 7.1 as you can see on the issue https://github.com/realm/jazzy/issues/288.

I add it too to the Gemfile in a development group, so from now it's possible to exec `bundle install --with development` to include jazzy, or simply `bundle install` to install without it.